### PR TITLE
Create helm chart for guestbook app

### DIFF
--- a/charts/guestbook/Chart.yaml
+++ b/charts/guestbook/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart to deploy Guestbook three tier web application.
+name: guestbook
+version: 0.1.0

--- a/charts/guestbook/README.md
+++ b/charts/guestbook/README.md
@@ -1,0 +1,46 @@
+# guestbook: an example chart for educational purpose.
+
+This chart provides example of some of the important features of Helm.
+
+The chart installs a [guestbook](https://github.com/IBM/guestbook/tree/master/v1) application.
+
+## Installing the Chart
+
+To install the chart with the default release name:
+
+```bash
+$ helm install charts/guestbook
+```
+
+To install the chart with your preference of release name, for example, `my-release`:
+
+```bash
+$ helm install --name my-release charts/guestbook
+```
+
+### Uninstalling the Chart
+
+To completely uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete --purge my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the chart and their default values.
+
+| Parameter                  | Description                                     | Default                                                    |
+| -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
+| `image.repository`         | Image repository                                | `ibmcom/guestbook`                                         |
+| `image.tag`                | Image tag                                       | `v1`                                                       |
+| `image.pullPolicy`         | Image pull policy                               | `Always`                                                   |
+| `serviceType`              | Service type                                    | `LoadBalancer`                                             |
+
+Specify each parameter using the `--set [key=value]` argument to `helm install`. For exampme,
+
+```bash
+$ helm install --set serviceType=NodePort charts/guestbook
+```

--- a/charts/guestbook/templates/NOTES.txt
+++ b/charts/guestbook/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "guestbook.name" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "guestbook.name" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "guestbook.name" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "guestbook.name" . }})
+  echo http://$SERVICE_IP:$PORT
+{{- end }}

--- a/charts/guestbook/templates/_helpers.tpl
+++ b/charts/guestbook/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "guestbook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "guestbook.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/guestbook/templates/guestbook-deployment.yaml
+++ b/charts/guestbook/templates/guestbook-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "guestbook.fullname" . }}
+  labels:
+    app: {{ template "guestbook.name" . }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+  template:
+    metadata:
+      labels:
+        app: guestbook
+    spec:
+      containers:
+      - name: guestbook
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        ports:
+        - name: http-server
+          containerPort: 3000
+        imagePullPolicy: {{ .Values.pullPolicy }}

--- a/charts/guestbook/templates/guestbook-service.yaml
+++ b/charts/guestbook/templates/guestbook-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "guestbook.fullname" . }}
+  labels:
+    app: {{ template "guestbook.name" . }}
+spec:
+  ports:
+  - port: 3000
+    targetPort: http-server
+  selector:
+    app: guestbook
+  type: {{ .Values.serviceType }}

--- a/charts/guestbook/templates/redis-master-deployment.yaml
+++ b/charts/guestbook/templates/redis-master-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    role: master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+    spec:
+      containers:
+      - name: redis-master
+        image: redis:2.8.23
+        ports:
+        - name: redis-server
+          containerPort: 6379

--- a/charts/guestbook/templates/redis-master-service.yaml
+++ b/charts/guestbook/templates/redis-master-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    role: master
+spec:
+  ports:
+  - port: 6379
+    targetPort: redis-server
+  selector:
+    app: redis
+    role: master

--- a/charts/guestbook/templates/redis-slave-deployment.yaml
+++ b/charts/guestbook/templates/redis-slave-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    role: slave
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+    spec:
+      containers:
+      - name: redis-slave
+        image: kubernetes/redis-slave:v2
+        ports:
+        - name: redis-server
+          containerPort: 6379

--- a/charts/guestbook/templates/redis-slave-service.yaml
+++ b/charts/guestbook/templates/redis-slave-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    role: slave
+spec:
+  ports:
+  - port: 6379
+    targetPort: redis-server
+  selector:
+    app: redis
+    role: slave

--- a/charts/guestbook/values.yaml
+++ b/charts/guestbook/values.yaml
@@ -1,0 +1,10 @@
+# IBM Guestbook image version ibmcom/guestbook:v1
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: ibmcom/guestbook
+  tag: v1
+  pullPolicy: Always
+
+# For minikube you may want to set serviceType from LoadBalancer to NodePort
+serviceType: LoadBalancer


### PR DESCRIPTION
Convert guestbook app into a helm chart. This chart will be used
for demo. This 101 type chart is created with specific usage in mind like
how helm can be used easily in compare to straight kubernetes deployment
via passing values at runtime etc.

partially fixes # https://github.ibm.com/IBMCode/IBMCodeContent/issues/409