### PR TITLE
steps are slightly different for Helm v3.x

### DIFF
--- a/tutorial/Lab0/README.md
+++ b/tutorial/Lab0/README.md
@@ -1,12 +1,14 @@
 # Lab 0. Installing Helm on IBM Cloud Kubernetes Service
 
-There are two parts to installing Helm: the client (helm) and the server (Tiller). Helm can be installed from source or pre-built binary releases. In this lab, we are going to use the pre-built binary release (Linux amd64) from the Helm community. Refer to the [Helm install docs](https://docs.helm.sh/using_helm/#install-helm) for more details. 
+Tiller was the Helm server component before Helm v3 and was removed since Helm v3.
+
+Helm can be installed from source or pre-built binary releases. In this lab, we are going to use the pre-built binary release (Linux amd64) from the Helm community. Refer to the [Helm install docs](https://docs.helm.sh/using_helm/#install-helm) for more details. 
 
 # Prerequisites
 
 Create a Kubernetes cluster with [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers/cs_tutorials.html#cs_cluster_tutorial), following the steps to also configure the IBM Cloud CLI with the Kubernetes Service plug-in.
 
-# Installing the Helm Client (helm)
+# Installing the Helm CLI
 
 1. Download the [latest release Helm](https://github.com/helm/helm/releases) for your environment, which in this case is `Linux amd64`.
 
@@ -14,13 +16,7 @@ Create a Kubernetes cluster with [IBM Cloud Kubernetes Service](https://cloud.ib
 
 3. Find the helm binary in the unpacked directory, and move it to its desired location: `mv linux-amd64/helm /usr/local/bin/helm`. It is best if the location you copy to is pathed, as it avoids having to path the helm commands.
 
-4. The Helm client is now installed and can be tested with the command, `helm help`. Refer to the doc [installing Client](https://docs.helm.sh/using_helm/#installing-the-helm-client) for more details.
-
-# Installing the Helm Server (Tiller)
-
-1. Run the command: `$ helm init`. This will initialize the Helm CLI and also install Tiller into the Kubernetes cluster under the `tiller-namespace`.
-
-2. You can verify that the client and server are installed correctly by running the command, `helm version`. This should return both the client and server versions. Refer to the doc [installing Tiller](https://docs.helm.sh/using_helm/#installing-tiller) for more details.
+4. The Helm CLI is now installed and can be tested with the command, `helm help`. Refer to the doc [installing Client](https://docs.helm.sh/using_helm/#installing-the-helm-client) for more details.
 
 # Conclusion
 

--- a/tutorial/Lab1/README.md
+++ b/tutorial/Lab1/README.md
@@ -95,45 +95,26 @@ Let's go ahead and install the chart now.
 
 1. Install the app as a Helm chart:
 
-    ```$ helm install ./guestbook/ --name guestbook-demo --namespace helm-demo```
+    ```$ helm install guestbook-demo ./guestbook/ --namespace helm-demo```
     
     Note: `$ helm install` command will create the `helm-demo` namespace if it does not exist.
     
     You should see output similar to the following:
     
-    ```console
-    NAME:   guestbook-demo
-    LAST DEPLOYED: Fri Sep 21 14:26:01 2018
-    NAMESPACE: helm-demo
-    STATUS: DEPLOYED
-    
-    RESOURCES:
-    ==> v1/Service
-    NAME            AGE
-    guestbook-demo  0s
-    redis-master    0s
-    redis-slave     0s
-    
-    ==> v1/Deployment
-    guestbook-demo  0s
-    redis-master    0s
-    redis-slave     0s
-
-    ==> v1/Pod(related)
-    NAME                             READY  STATUS             RESTARTS  AGE
-    guestbook-demo-5dccd68c88-hqlws  0/1    ContainerCreating  0         0s
-    guestbook-demo-5dccd68c88-sdhcv  0/1    ContainerCreating  0         0s
-    redis-master-5d8b66464f-g9q7m    0/1    ContainerCreating  0         0s
-    redis-slave-586b4c847c-ct77m     0/1    ContainerCreating  0         0s
-    redis-slave-586b4c847c-nrzwj     0/1    ContainerCreating  0         0s
-
-    NOTES:
-    1. Get the application URL by running these commands:
-      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-            You can watch the status of by running 'kubectl get svc -w guestbook-demo --namespace helm-demo'
-      export SERVICE_IP=$(kubectl get svc --namespace helm-demo guestbook-demo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-      echo http://$SERVICE_IP:3000
-    ```
+   ```console
+   NAME: guestbook-demo
+   LAST DEPLOYED: Wed Feb 19 18:02:11 2020
+   NAMESPACE: helm-demo
+   STATUS: deployed
+   REVISION: 1
+   TEST SUITE: None
+   NOTES:
+   1. Get the application URL by running these commands:
+    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w guestbook-demo --namespace helm-demo'
+     export SERVICE_IP=$(kubectl get svc --namespace helm-demo guestbook-demo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+     echo http://$SERVICE_IP:3000
+   ```
     
     The chart install performs the Kubernetes deployments and service creations of the redis master and slaves, and the guestbook app, as one. This is because the chart is a collection of files that describe a related set of Kubernetes resources and Helm manages the creation of these resources via the Kubernetes API.    
     
@@ -141,10 +122,10 @@ Let's go ahead and install the chart now.
     
     You should see output similar to the following:
     
-    ```console
-    NAME             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-    guestbook-demo   2         2         2            2           51m
-    ```
+   ```console
+   NAME             READY   UP-TO-DATE   AVAILABLE   AGE
+   guestbook-demo   2/2     2            2           3m5s
+   ```
     
     To check the status of the running application, you can use `$ kubectl get pods --namespace helm-demo`.
     

--- a/tutorial/Lab2/README.md
+++ b/tutorial/Lab2/README.md
@@ -114,28 +114,12 @@ Enough talking about the theory. Now let's give it a go!
     
     ```console
     Release "guestbook-demo" has been upgraded. Happy Helming!
-    LAST DEPLOYED: Mon Sep 24 10:36:18 2018
+    NAME: guestbook-demo
+    LAST DEPLOYED: Wed Feb 19 18:14:43 2020
     NAMESPACE: helm-demo
-    STATUS: DEPLOYED
-    
-    RESOURCES:
-    ==> v1/Service
-    NAME            AGE
-    guestbook-demo  1h
-    redis-master    1h
-    
-    ==> v1/Deployment
-    guestbook-demo  1h
-    redis-master    1h
-    
-    ==> v1/Pod(related)
-    
-    NAME                           READY  STATUS   RESTARTS  AGE
-    guestbook-demo-6c9cf8b9-dhqk9  1/1    Running  0         1h
-    guestbook-demo-6c9cf8b9-zddn2  1/1    Running  0         1h
-    redis-master-5d8b66464f-g7sh6  1/1    Running  0         1h
-    
-    
+    STATUS: deployed
+    REVISION: 2
+    TEST SUITE: None
     NOTES:
     1. Get the application URL by running these commands:
       export NODE_PORT=$(kubectl get --namespace helm-demo -o jsonpath="{.spec.ports[0].nodePort}" services guestbook-demo)

--- a/tutorial/Lab3/README.md
+++ b/tutorial/Lab3/README.md
@@ -17,35 +17,35 @@ Let's see how this works in practice.
 1. Check the number of deployments:
 
     ```console
-    $ helm history guestbook-demo
+    $ helm history guestbook-demo --namespace helm-demo
     ```
     
     You should see output similar to the following because we did an upgrade in [Lab 2](../Lab2/README.md) after the initial install in [Lab 1](../Lab1/README.md):
     
     ```console
-    REVISION	UPDATED                 	STATUS    	CHART          	DESCRIPTION
-    1       	Mon Sep 24 08:54:04 2018	SUPERSEDED	guestbook-0.1.0	Install complete
-    2       	Mon Sep 24 10:36:18 2018	DEPLOYED  	guestbook-0.1.0	Upgrade complete
+    REVISION        UPDATED                         STATUS          CHART           APP VERSION     DESCRIPTION     
+    1               Wed Feb 19 18:02:11 2020        superseded      guestbook-0.2.0                 Install complete
+    2               Wed Feb 19 18:14:43 2020        deployed        guestbook-0.2.0                 Upgrade complete
     ```
         
 2. Roll back to the previous revision:
 
     In this rollback, Helm checks the changes that occured when upgrading from the revision 1 to revision 2. This information enables it to makes the calls to the Kubernetes API server, to update the deployed application as per the initial deployment - in other words with Redis slaves and using a load balancer.
 
-    Rollback with this command, ```$ helm rollback guestbook-demo 1```
+    Rollback with this command, ```$ helm rollback guestbook-demo 1 --namespace helm-demo```
     
     ```console
     Rollback was a success! Happy Helming!
     ```
-    Check the history again, `$ helm history guestbook-demo`
+    Check the history again, `$ helm history guestbook-demo --namespace helm-demo`
     
     You should see output similar to the following:
     
     ```console
-    REVISION	UPDATED                 	STATUS    	CHART          	DESCRIPTION     
-    1       	Mon Sep 24 08:54:04 2018	SUPERSEDED	guestbook-0.1.0	Install complete
-    2       	Mon Sep 24 10:36:18 2018	SUPERSEDED	guestbook-0.1.0	Upgrade complete
-    3       	Mon Sep 24 11:59:18 2018	DEPLOYED  	guestbook-0.1.0	Rollback to 1
+    REVISION        UPDATED                         STATUS          CHART           APP VERSION     DESCRIPTION     
+    1               Wed Feb 19 18:02:11 2020        superseded      guestbook-0.2.0                 Install complete
+    2               Wed Feb 19 18:14:43 2020        superseded      guestbook-0.2.0                 Upgrade complete
+    3               Wed Feb 19 18:25:40 2020        deployed        guestbook-0.2.0                 Rollback to 1  
     ```
     
     To check the rollback, you can run `$ kubectl get all --namespace helm-demo`:

--- a/tutorial/Lab4/README.md
+++ b/tutorial/Lab4/README.md
@@ -17,12 +17,10 @@ In this part of the lab, we show you how to install the `guestbook` chart from t
    The output should be similar to the following:
    
    ```console
-   NAME  	URL                                             
-   stable	https://kubernetes-charts.storage.googleapis.com
-   local 	http://127.0.0.1:8879/charts                   
+   Error: no repositories to show
    ```
    
-   Note: The Helm charts repository is installed by default with Helm. It is installed with the repositories `local` and `stable`. You can run the `local` repo using the [helm serve](https://github.com/helm/helm/blob/master/docs/helm/helm_serve.md) command. The `stable` repo is located at `https://kubernetes-charts.storage.googleapis.com/`.
+   Note: No Helm charts repository is installed by default with Helm v3.1.
 
 2. Add `helm101` repo:
 
@@ -32,7 +30,7 @@ In this part of the lab, we show you how to install the `guestbook` chart from t
    
    ```"helmm101" has been added to your repositories```
    
-   You can also search your repositories for charts by running the following command, ```$ helm search helm101```:
+   You can also search your repositories for charts by running the following command, ```$ helm search repo helm101```:
    
    ```console
    NAME             	CHART VERSION	APP VERSION	DESCRIPTION                                                 
@@ -43,44 +41,59 @@ In this part of the lab, we show you how to install the `guestbook` chart from t
 
    As mentioned we are going to install the `guestbook` chart from the [Helm101 repo](https://ibm.github.io/helm101/). As the repo is installed in our local respoitory we can reference the chart using the `repo name/chart name`, in other words `helm101/guestbook`. This means we can install the chart like we did previously with the command:
 
-   ```$ helm install helm101/guestbook --name guestbook-demo --namespace repo-demo```
+   ```$ helm install guestbook-demo-repo helm101/guestbook --namespace repo-demo```
    
    The output should be similar to the following:
    
    ```console
-   NAME:   guestbook-demo
-   LAST DEPLOYED: Thu Dec 13 07:36:18 2018
+   NAME: guestbook-demo-repo
+   LAST DEPLOYED: Wed Feb 19 18:38:35 2020
    NAMESPACE: repo-demo
-   STATUS: DEPLOYED
-   
-   RESOURCES:
-   ==> v1/Service
-   NAME                      TYPE          CLUSTER-IP     EXTERNAL-IP  PORT(S)         AGE
-   guestbook-demo-guestbook  LoadBalancer  10.98.43.107   <pending>    3000:31241/TCP  2s
-   redis-master              ClusterIP     10.103.16.208  <none>       6379/TCP        2s
-   redis-slave               ClusterIP     10.99.249.122  <none>       6379/TCP        2s
-   
-   ==> v1/Deployment
-   NAME                      READY  UP-TO-DATE  AVAILABLE  AGE
-   guestbook-demo-guestbook  0/2    2           0          2s
-   redis-master              0/1    1           0          2s
-   redis-slave               0/2    2           0          2s
-   
-   ==> v1/Pod(related)
-   NAME                                       READY  STATUS             RESTARTS  AGE
-   guestbook-demo-guestbook-75f5f9cf84-jcbtb  0/1    Pending            0         2s
-   guestbook-demo-guestbook-75f5f9cf84-lzsw4  0/1    ContainerCreating  0         2s
-   redis-master-7b5cc58fc8-2bzw6              0/1    ContainerCreating  0         2s
-   redis-slave-5db5dcfdfd-24249               0/1    ContainerCreating  0         2s
-   redis-slave-5db5dcfdfd-nkcpt               0/1    ContainerCreating  0         1s
-   
-   
+   STATUS: deployed
+   REVISION: 1
+   TEST SUITE: None
    NOTES:
-   Get the application URL by running these commands:
-   export NODE_PORT=$(kubectl get --namespace repo-demo -o jsonpath="{.spec.ports[0].nodePort}" services guestbook-demo-guestbook)
-   export NODE_IP=$(kubectl get nodes -o jsonpath={.items[*].status.addresses[?\(@.type==\"ExternalIP\"\)].address})
-   echo http://$NODE_IP:$NODE_PORT```
+   1. Get the application URL by running these commands:
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w guestbook-demo-repo --namespace repo-demo'
+     export SERVICE_IP=$(kubectl get svc --namespace repo-demo guestbook-demo-repo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+     echo http://$SERVICE_IP:3000
+   ```
    
+4. Verify the new release
+
+   To check the new release, you can run
+
+   ```
+   $ kubectl get all --namespace repo-demo
+   ```
+
+   The command should returns
+
+   ```console
+   NAME                                       READY   STATUS             RESTARTS   AGE
+   pod/guestbook-demo-repo-7c65cfd8d6-2z7qc   1/1     Running            0          4m41s
+   pod/guestbook-demo-repo-7c65cfd8d6-9b96v   1/1     Running            0          4m41s
+   pod/redis-master-65b496655c-v7fbw          1/1     Running            0          4m41s
+   pod/redis-slave-775f8c567f-6rb8b           0/1     ImagePullBackOff   0          4m41s
+   pod/redis-slave-775f8c567f-m9zcz           0/1     ImagePullBackOff   0          4m41s
+
+   NAME                          TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)          AGE
+   service/guestbook-demo-repo   LoadBalancer   172.21.245.164   169.46.44.178   3000:32674/TCP   4m41s
+   service/redis-master          ClusterIP      172.21.22.93     <none>          6379/TCP         4m41s
+   service/redis-slave           ClusterIP      172.21.21.52     <none>          6379/TCP         4m41s
+
+   NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
+   deployment.apps/guestbook-demo-repo   2/2     2            2           4m41s
+   deployment.apps/redis-master          1/1     1            1           4m41s
+   deployment.apps/redis-slave           0/2     2            0           4m41s
+
+   NAME                                             DESIRED   CURRENT   READY   AGE
+   replicaset.apps/guestbook-demo-repo-7c65cfd8d6   2         2         2       4m41s
+   replicaset.apps/redis-master-65b496655c          1         1         1       4m41s
+   replicaset.apps/redis-slave-775f8c567f           2         2         0       4m41s
+   ```
+
 # Conclusion
 
 This lab provided you with a brief introduction to the Helm repositories to show how charts can be installed. The ability to share your chart means ease of use to both you and your consumers.


### PR DESCRIPTION
I found this great asset couple of weeks ago. Much better than what I had used.

The assets were written in Helm v2.x and steps are slightly different for Helm v3.x. I tested all 5 labs in Helm v3.1 and modified commands and outputs accordingly.

However, I did not modify the overall tutorial README.md. It needs modifications for the architecture changes since Helm v3.

Since the instructions are different for Helm before and after v3, perhaps the repo needs a new. branch or maybe a new repo.

Thanks for this great asset.
Lee Z