### PR TITLE
fix(docs): Update the Helm doc links following Helm 3 GA

### DIFF
--- a/tutorial/Lab0/README.md
+++ b/tutorial/Lab0/README.md
@@ -1,6 +1,6 @@
 # Lab 0. Installing Helm on IBM Cloud Kubernetes Service
 
-There are two parts to installing Helm: the client (helm) and the server (Tiller). Helm can be installed from source or pre-built binary releases. In this lab, we are going to use the pre-built binary release (Linux amd64) from the Helm community. Refer to the [Helm install docs](https://docs.helm.sh/using_helm/#install-helm) for more details. 
+There are two parts to installing Helm: the client (helm) and the server (Tiller). Helm can be installed from source or pre-built binary releases. In this lab, we are going to use the pre-built binary release (Linux amd64) from the Helm community. Refer to the [Helm install docs](https://v2.helm.sh/docs/using_helm/#install-helm) for more details. 
 
 # Prerequisites
 
@@ -14,13 +14,13 @@ Create a Kubernetes cluster with [IBM Cloud Kubernetes Service](https://cloud.ib
 
 3. Find the helm binary in the unpacked directory, and move it to its desired location: `mv linux-amd64/helm /usr/local/bin/helm`. It is best if the location you copy to is pathed, as it avoids having to path the helm commands.
 
-4. The Helm client is now installed and can be tested with the command, `helm help`. Refer to the doc [installing Client](https://docs.helm.sh/using_helm/#installing-the-helm-client) for more details.
+4. The Helm client is now installed and can be tested with the command, `helm help`. Refer to the doc [installing Client](https://v2.helm.sh/docs/using_helm/#installing-the-helm-client) for more details.
 
 # Installing the Helm Server (Tiller)
 
 1. Run the command: `$ helm init`. This will initialize the Helm CLI and also install Tiller into the Kubernetes cluster under the `tiller-namespace`.
 
-2. You can verify that the client and server are installed correctly by running the command, `helm version`. This should return both the client and server versions. Refer to the doc [installing Tiller](https://docs.helm.sh/using_helm/#installing-tiller) for more details.
+2. You can verify that the client and server are installed correctly by running the command, `helm version`. This should return both the client and server versions. Refer to the doc [installing Tiller](https://v2.helm.sh/docs/using_helm/#installing-tiller) for more details.
 
 # Conclusion
 

--- a/tutorial/Lab2/README.md
+++ b/tutorial/Lab2/README.md
@@ -79,7 +79,7 @@ In this part of the lab we will update the previously deployed application [Gues
 
 In this section, we'll update the previously deployed `guestbook-demo` application by using Helm.
 
-Before we start, let's take a few minutes to see how Helm simplifies the process compared to using Kubernetes directly. Helm's use of a [template language](https://docs.helm.sh/chart_template_guide/) provides great flexibility and power to chart authors, which removes the complexity to the chart user. In the guestbook example, we'll use the following capabilities of templating:
+Before we start, let's take a few minutes to see how Helm simplifies the process compared to using Kubernetes directly. Helm's use of a [template language](https://v2.helm.sh/docs/chart_template_guide/) provides great flexibility and power to chart authors, which removes the complexity to the chart user. In the guestbook example, we'll use the following capabilities of templating:
 * Values: An object that provides access to the values passed into the chart. An example of this is in `guestbook-service`, which contains the line `type: {{ .Values.service.type }}`. This line provides the capability to set the service type during an upgrade or install.
 * Control structures: Also called “actions” in template parlance, control structures provide the template author with the ability to control the flow of a template’s generation. An example of this is in `redis-slave-service`, which contains the line `{{- if .Values.redis.slaveEnabled -}}`. This line allows us to enable/disable the REDIS master/slave during an upgrade or install.
 

--- a/tutorial/Lab4/README.md
+++ b/tutorial/Lab4/README.md
@@ -6,7 +6,7 @@ A means of sharing is a chart repository, which is a location where packaged cha
 
 # Using charts from a public repository
 
-Helm charts can be available on a remote repository or in a local environment/repository. The remote repositories can be public like [Helm Charts](https://github.com/helm/charts) or [IBM Helm Charts](https://github.com/IBM/charts), or hosted repositories like on Google Cloud Storage or GitHub. Refer to [Helm Chart Repository Guide](https://github.com/helm/helm/blob/master/docs/chart_repository.md) for more details. 
+Helm charts can be available on a remote repository or in a local environment/repository. The remote repositories can be public like [Helm Charts](https://github.com/helm/charts) or [IBM Helm Charts](https://github.com/IBM/charts), or hosted repositories like on Google Cloud Storage or GitHub. Refer to [Helm Chart Repository Guide](https://v2.helm.sh/docs/developing_charts/#the-chart-repository-guide) for more details. 
 
 In this part of the lab, we show you how to install the `guestbook` chart from the [Helm101 repo](https://ibm.github.io/helm101/).
 
@@ -22,7 +22,7 @@ In this part of the lab, we show you how to install the `guestbook` chart from t
    local 	http://127.0.0.1:8879/charts                   
    ```
    
-   Note: The Helm charts repository is installed by default with Helm. It is installed with the repositories `local` and `stable`. You can run the `local` repo using the [helm serve](https://github.com/helm/helm/blob/master/docs/helm/helm_serve.md) command. The `stable` repo is located at `https://kubernetes-charts.storage.googleapis.com/`.
+   Note: The Helm charts repository is installed by default with Helm. It is installed with the repositories `local` and `stable`. You can run the `local` repo using the [helm serve](https://v2.helm.sh/docs/helm/#helm-serve) command. The `stable` repo is located at `https://kubernetes-charts.storage.googleapis.com/`.
 
 2. Add `helm101` repo:
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,6 +1,6 @@
 # Why Helm?
 
-[Helm](https://docs.helm.sh/) is often described as the Kubernetes application package manager. So, what does Helm give you over using kubectl directly?
+[Helm](https://v2.helm.sh/) is often described as the Kubernetes application package manager. So, what does Helm give you over using kubectl directly?
 
 # Objectives
 
@@ -16,7 +16,7 @@ These labs provide an insight on the advantages of using Helm over using Kuberne
 # Prerequisites
 
 * Have a running Kubernetes cluster. See the [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers/cs_tutorials.html#cs_cluster_tutorial) or [Kubernetes Getting Started Guide](https://kubernetes.io/docs/setup/) for details about creating a cluster.
-* Have Helm installed and initialized with the Kubernetes cluster. See [Installing Helm on IBM Cloud Kubernetes Service](Lab0/README.md) or the [Helm Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart) for getting started with Helm.
+* Have Helm installed and initialized with the Kubernetes cluster. See [Installing Helm on IBM Cloud Kubernetes Service](Lab0/README.md) or the [Helm Quickstart Guide](https://v2.helm.sh/docs/using_helm/#quickstart) for getting started with Helm.
 
 # Helm Overview
 
@@ -24,18 +24,18 @@ Helm is a tool that streamlines installation and management of Kubernetes applic
 
 ![helm-architecture](images/helm-architecture.png)
 
-It has a client-server architecture with the client called `helm` and the server called `Tiller`. The client is a CLI which users interact with to perform different operations like install/upgrade/delete etc. The client interacts with Tiller and the chart repository. Tiller interacts with the Kubernetes API server. It renders Helm template files into Kubernetes manifest files which it uses to perform operations on the Kubernetes cluster via the Kubernetes API. See the [Helm Architecture](https://docs.helm.sh/architecture/) for more details. 
+It has a client-server architecture with the client called `helm` and the server called `Tiller`. The client is a CLI which users interact with to perform different operations like install/upgrade/delete etc. The client interacts with Tiller and the chart repository. Tiller interacts with the Kubernetes API server. It renders Helm template files into Kubernetes manifest files which it uses to perform operations on the Kubernetes cluster via the Kubernetes API. See the [Helm Architecture](https://v2.helm.sh/docs/architecture/) for more details. 
 
-A [chart](https://docs.helm.sh/developing_charts) is organized as a collection of files inside of a directory where the directory name is the name of the chart. It contains template YAML files which facilitates providing configuration values at runtime and eliminates the need of modifying YAML files. These templates provide programming logic as they are based on the [Go template language](https://golang.org/pkg/text/template/), functions from the [Sprig lib](https://github.com/Masterminds/sprig) and other [specialized functions](https://docs.helm.sh/developing_charts/#chart-development-tips-and-tricks).
+A [chart](https://v2.helm.sh/docs/developing_charts) is organized as a collection of files inside of a directory where the directory name is the name of the chart. It contains template YAML files which facilitates providing configuration values at runtime and eliminates the need of modifying YAML files. These templates provide programming logic as they are based on the [Go template language](https://golang.org/pkg/text/template/), functions from the [Sprig lib](https://github.com/Masterminds/sprig) and other [specialized functions](https://v2.helm.sh/docs/developing_charts/#chart-development-tips-and-tricks).
 
-The chart repository is a location where packaged charts can be stored and shared. This is akin to the image repository in Docker. Refer to [The Chart Repository Guide](https://github.com/helm/helm/blob/master/docs/chart_repository.md) for more details.
+The chart repository is a location where packaged charts can be stored and shared. This is akin to the image repository in Docker. Refer to [The Chart Repository Guide](ihttps://v2.helm.sh/docs/developing_charts/#the-chart-repository-guide) for more details.
 
 # Helm Abstractions
 
 Helm terms :
 * Chart - It contains all of the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster. A chart is basically a package of pre-configured Kubernetes resources.
 * Config - Contains configuration information that can be merged into a packaged chart to create a releasable object.
-* helm - Helm client. Communicates to Tiller through the Helm API - [HAPI](https://docs.helm.sh/developers/#the-helm-api-hapi) which uses [gRPC](https://grpc.io/).
+* helm - Helm client. Communicates to Tiller through the Helm API - [HAPI](https://v2.helm.sh/docs/developers/#the-helm-api-hapi) which uses [gRPC](https://grpc.io/).
 * Release - An instance of a chart running in a Kubernetes cluster.
 * Repository - Place where charts reside and can be shared with others.
 * Tiller - Helm server. It interacts directly with the [Kubernetes API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/) server to install, upgrade, query, and remove Kubernetes resources.


### PR DESCRIPTION
The links to Helm docs have changed after Helm 3 went GA and replaced Helm 2 as the latest version of Helm. This PR updates the links to point to the correct Helm 2 docs.

Fixes #29 